### PR TITLE
Charcoal is no longer on strike

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,8 +5,6 @@ search_title: Home
 
 {% img name.png height:"100" width class:"block-center" %}
 
-# Notice (June 2023): SmokeDetector has been shut down until further notice due to a [content moderation strike](https://openletter.mousetail.nl/).
-
 [Charcoal](https://chat.stackexchange.com/rooms/11540) are the people behind
 [SmokeDetector](https://github.com/Charcoal-SE/SmokeDetector),
 a community bot to detect spam on the


### PR DESCRIPTION
Charcoal/SD [is back up](https://chat.stackexchange.com/transcript/message/64130740), so this message is no longer correct. This PR essentially is the opposite of [this commit](https://github.com/Charcoal-SE/charcoal-se.github.io/commit/6d0aa72fba19d8c3d508e585d82f39965ceb68c1).